### PR TITLE
[FEAT] 회원탈퇴 API 생성

### DIFF
--- a/src/main/java/com/project/user/domain/application/dto/request/UserDeletionRequest.java
+++ b/src/main/java/com/project/user/domain/application/dto/request/UserDeletionRequest.java
@@ -1,0 +1,7 @@
+package com.project.user.domain.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserDeletionRequest (
+        @NotBlank String password
+) {}

--- a/src/main/java/com/project/user/domain/application/usecase/UserDeletionUseCase.java
+++ b/src/main/java/com/project/user/domain/application/usecase/UserDeletionUseCase.java
@@ -1,0 +1,49 @@
+package com.project.user.domain.application.usecase;
+
+import com.project.user.domain.application.dto.request.UserDeletionRequest;
+import com.project.user.domain.domain.entity.User;
+import com.project.user.domain.domain.service.RefreshTokenService;
+import com.project.user.domain.domain.service.TokenBlacklistService;
+import com.project.user.domain.domain.service.UserService;
+import com.project.user.global.exception.RestApiException;
+import com.project.user.global.security.TokenProvider;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static com.project.user.global.exception.code.status.AuthErrorStatus.INVALID_ACCESS_TOKEN;
+import static com.project.user.global.exception.code.status.AuthErrorStatus.INVALID_ID_TOKEN;
+import static com.project.user.global.exception.code.status.AuthErrorStatus.INVALID_PASSWORD;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserDeletionUseCase {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+
+    public void execute(String accessToken, UserDeletionRequest request) {
+        Long userNo = tokenProvider.getId(accessToken)
+                .orElseThrow(() -> new RestApiException(INVALID_ID_TOKEN));
+
+        User user = userService.findById(userNo);
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new RestApiException(INVALID_PASSWORD);
+        }
+
+        Duration expiration = tokenProvider.getRemainingDuration(accessToken)
+                .orElseThrow(() -> new RestApiException(INVALID_ACCESS_TOKEN));
+
+        refreshTokenService.deleteRefreshToken(userNo);
+        tokenBlacklistService.blacklist(accessToken, expiration);
+        userService.deleteUser(userNo);
+    }
+}

--- a/src/main/java/com/project/user/domain/domain/service/UserService.java
+++ b/src/main/java/com/project/user/domain/domain/service/UserService.java
@@ -7,6 +7,7 @@ import com.project.user.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.project.user.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
 
@@ -46,5 +47,10 @@ public class UserService {
     public void validateExistsById(Long userNo) {
         if (!userRepository.existsById(userNo))
             throw new RestApiException(_NOT_FOUND);
+    }
+
+    @Transactional
+    public void deleteUser(Long userNo) {
+        userRepository.deleteById(userNo);
     }
 }

--- a/src/main/java/com/project/user/domain/ui/UserDeletionController.java
+++ b/src/main/java/com/project/user/domain/ui/UserDeletionController.java
@@ -1,0 +1,29 @@
+package com.project.user.domain.ui;
+
+import com.project.user.domain.application.dto.request.UserDeletionRequest;
+import com.project.user.domain.application.usecase.UserDeletionUseCase;
+import com.project.user.domain.ui.spec.UserDeletionApiSpec;
+import com.project.user.global.annotation.AccessToken;
+import com.project.user.global.annotation.CurrentUser;
+import com.project.user.global.common.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserDeletionController implements UserDeletionApiSpec {
+
+    private final UserDeletionUseCase userDeletionUseCase;
+
+    @Override
+    public BaseResponse<Void> deleteUser(
+            @CurrentUser Long userNo,
+            @AccessToken String accessToken,
+            @RequestBody @Valid UserDeletionRequest request
+    ) {
+        userDeletionUseCase.execute(accessToken, request);
+        return BaseResponse.onSuccess();
+    }
+}

--- a/src/main/java/com/project/user/domain/ui/spec/UserDeletionApiSpec.java
+++ b/src/main/java/com/project/user/domain/ui/spec/UserDeletionApiSpec.java
@@ -1,0 +1,31 @@
+package com.project.user.domain.ui.spec;
+
+import com.project.user.domain.application.dto.request.UserDeletionRequest;
+import com.project.user.global.annotation.AccessToken;
+import com.project.user.global.annotation.CurrentUser;
+import com.project.user.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User Deletion", description = "회원 탈퇴 API")
+public interface UserDeletionApiSpec {
+
+    @Operation(summary = "회원 탈퇴", description = "비밀번호를 확인하여 회원을 탈퇴시키는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "회원 정보 없음"),
+            @ApiResponse(responseCode = "400", description = "비밀번호 불일치 또는 잘못된 요청")
+    })
+    @DeleteMapping("/api/users")
+    BaseResponse<Void> deleteUser(
+            @CurrentUser Long userNo,
+            @AccessToken String accessToken,
+            @RequestBody @Valid UserDeletionRequest request
+    );
+}

--- a/src/main/java/com/project/user/global/exception/code/status/AuthErrorStatus.java
+++ b/src/main/java/com/project/user/global/exception/code/status/AuthErrorStatus.java
@@ -24,6 +24,8 @@ public enum AuthErrorStatus implements BaseCodeInterface {
     NOT_VERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH009", "인증되지 않은 이메일입니다."),
     INVALID_EMAIL_DOMAIN(HttpStatus.BAD_REQUEST, "AUTH009", "유효하지 않은 이메일 도메인입니다."),
     FAILED_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, "AUTH009", "이메일 인증에 실패하였습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH010", "비밀번호가 일치하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/project/user/domain/application/usecase/UserDeletionUseCaseTest.java
+++ b/src/test/java/com/project/user/domain/application/usecase/UserDeletionUseCaseTest.java
@@ -1,0 +1,196 @@
+package com.project.user.domain.application.usecase;
+
+import com.project.user.domain.application.dto.request.UserDeletionRequest;
+import com.project.user.domain.domain.entity.User;
+import com.project.user.domain.domain.service.RefreshTokenService;
+import com.project.user.domain.domain.service.TokenBlacklistService;
+import com.project.user.domain.domain.service.UserService;
+import com.project.user.global.exception.RestApiException;
+import com.project.user.global.security.TokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserDeletionUseCaseTest {
+
+    @Mock private TokenProvider tokenProvider;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private TokenBlacklistService tokenBlacklistService;
+    @Mock private UserService userService;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserDeletionUseCase useCase;
+
+    private final String accessToken = "Bearer xxx.yyy.zzz";
+    private final Long userNo = 42L;
+
+    private UserDeletionRequest req(String rawPassword) {
+        return new UserDeletionRequest(rawPassword);
+    }
+
+    private User userWithPassword(String encoded) {
+        return User.builder()
+                .email("user@test.com")
+                .name("name")
+                .nickname("nick")
+                .password(encoded)
+                .gender(null)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("정상 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("유효 토큰+비밀번호 일치+잔여기간 존재 → 리프레시 삭제→블랙리스트→유저 삭제 순서")
+        void execute_success() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            User user = userWithPassword("encoded");
+            when(userService.findById(userNo)).thenReturn(user);
+            when(passwordEncoder.matches("raw", "encoded")).thenReturn(true);
+            Duration remaining = Duration.ofMinutes(30);
+            when(tokenProvider.getRemainingDuration(accessToken)).thenReturn(Optional.of(remaining));
+
+            // When
+            useCase.execute(accessToken, req("raw"));
+
+            // Then
+            InOrder inOrder = inOrder(refreshTokenService, tokenBlacklistService, userService);
+            inOrder.verify(refreshTokenService).deleteRefreshToken(userNo);
+            inOrder.verify(tokenBlacklistService).blacklist(accessToken, remaining);
+            inOrder.verify(userService).deleteUser(userNo);
+
+            verifyNoMoreInteractions(refreshTokenService, tokenBlacklistService, userService);
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 케이스")
+    class ErrorCases {
+
+        @Test
+        @DisplayName("ID 토큰에서 userNo 파싱 실패 → RestApiException")
+        void execute_invalidIdToken() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThrows(RestApiException.class, () ->
+                    useCase.execute(accessToken, req("raw")));
+
+            verifyNoInteractions(userService, passwordEncoder, refreshTokenService, tokenBlacklistService);
+        }
+
+        @Test
+        @DisplayName("유저 조회 시 예외(_NOT_FOUND 등) → RestApiException")
+        void execute_userNotFound() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            when(userService.findById(userNo)).thenThrow(new RestApiException(null));
+
+            // When & Then
+            assertThrows(RestApiException.class, () ->
+                    useCase.execute(accessToken, req("raw")));
+
+            verifyNoInteractions(passwordEncoder, refreshTokenService, tokenBlacklistService);
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 → RestApiException, 후속 동작 없음")
+        void execute_invalidPassword() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            User user = userWithPassword("encoded");
+            when(userService.findById(userNo)).thenReturn(user);
+            when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
+
+            // When & Then
+            assertThrows(RestApiException.class, () ->
+                    useCase.execute(accessToken, req("wrong")));
+
+            verifyNoInteractions(refreshTokenService, tokenBlacklistService);
+            verify(userService, never()).deleteUser(anyLong());
+        }
+
+        @Test
+        @DisplayName("잔여 유효기간 조회 실패(Optional.empty) → RestApiException")
+        void execute_invalidAccessTokenExpiration() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            User user = userWithPassword("encoded");
+            when(userService.findById(userNo)).thenReturn(user);
+            when(passwordEncoder.matches("raw", "encoded")).thenReturn(true);
+            when(tokenProvider.getRemainingDuration(accessToken)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThrows(RestApiException.class, () ->
+                    useCase.execute(accessToken, req("raw")));
+
+            verifyNoInteractions(refreshTokenService, tokenBlacklistService);
+            verify(userService, never()).deleteUser(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("경계값 케이스")
+    class BoundaryCases {
+
+        @Test
+        @DisplayName("잔여 유효기간 = 0초 → 정상 처리되며 0초로 블랙리스트 등록")
+        void execute_zeroDuration() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            User user = userWithPassword("encoded");
+            when(userService.findById(userNo)).thenReturn(user);
+            when(passwordEncoder.matches("raw", "encoded")).thenReturn(true);
+            Duration remaining = Duration.ZERO;
+            when(tokenProvider.getRemainingDuration(accessToken)).thenReturn(Optional.of(remaining));
+
+            // When
+            useCase.execute(accessToken, req("raw"));
+
+            // Then
+            InOrder inOrder = inOrder(refreshTokenService, tokenBlacklistService, userService);
+            inOrder.verify(refreshTokenService).deleteRefreshToken(userNo);
+            inOrder.verify(tokenBlacklistService).blacklist(accessToken, remaining);
+            inOrder.verify(userService).deleteUser(userNo);
+        }
+
+        @Test
+        @DisplayName("잔여 유효기간 = 1초(매우 짧음) → 정상 처리")
+        void execute_oneSecondDuration() {
+            // Given
+            when(tokenProvider.getId(accessToken)).thenReturn(Optional.of(userNo));
+            User user = userWithPassword("encoded");
+            when(userService.findById(userNo)).thenReturn(user);
+            when(passwordEncoder.matches("raw", "encoded")).thenReturn(true);
+            Duration remaining = Duration.ofSeconds(1);
+            when(tokenProvider.getRemainingDuration(accessToken)).thenReturn(Optional.of(remaining));
+
+            // When
+            useCase.execute(accessToken, req("raw"));
+
+            // Then
+            verify(refreshTokenService).deleteRefreshToken(userNo);
+            verify(tokenBlacklistService).blacklist(accessToken, remaining);
+            verify(userService).deleteUser(userNo);
+        }
+    }
+}

--- a/src/test/java/com/project/user/domain/domain/service/UserServiceTest.java
+++ b/src/test/java/com/project/user/domain/domain/service/UserServiceTest.java
@@ -1,0 +1,4 @@
+package com.project.user.domain.domain.service;
+
+public class UserServiceTest {
+}

--- a/src/test/java/com/project/user/domain/domain/service/UserServiceTest.java
+++ b/src/test/java/com/project/user/domain/domain/service/UserServiceTest.java
@@ -1,4 +1,0 @@
-package com.project.user.domain.domain.service;
-
-public class UserServiceTest {
-}


### PR DESCRIPTION
## 📌 관련 이슈
- #7 

## ✨ 변경 사항
- 기능 추가: 회원탈퇴 기능 추가
- DELETE /api/users 엔드포인트를 구현하여 사용자 삭제 기능을 추가했습니다.
- 요청 본문(userId, password)을 통해 사용자 인증을 거친 후 계정을 삭제합니다.
<new>
- 기능 추가: 회원탈퇴(DELETE /api/users) 기능 구현 완료 및 기존 서비스 통합
- 아키텍처 개선 (인증): 요청 본문(userId)을 제거하고 Access Token 기반의 사용자 인증(@CurrentUser)으로 변경했습니다.
- 보안 기능 추가 (토큰 무효화): 회원탈퇴 시 해당 사용자의 Access Token과 Refresh Token을 즉시 무효화하고 **블랙리스트(Redis)**에 추가했습니다.
- 코드 리팩토링: UserDeletionService의 핵심 로직을 기존 UserService로 통합하여 도메인 서비스의 응집성을 높였습니다.

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 로컬에서 정상 동작 확인
- [ ] 관련 테스트 추가/수정 완료
- [ ] 문서화 필요 시 업데이트 완료

## 📸 스크린샷 (선택)

<img width="1296" height="951" alt="스크린샷 2025-09-29 오후 8 58 00" src="https://github.com/user-attachments/assets/f58df0d3-de01-4915-821c-36b6457cd0d1" />
<img width="1296" height="951" alt="스크린샷 2025-09-29 오후 9 05 19" src="https://github.com/user-attachments/assets/edf24f0c-e795-4377-b244-21676018d80f" />
<img width="1296" height="951" alt="스크린샷 2025-09-29 오후 9 06 27" src="https://github.com/user-attachments/assets/298c1b2c-3c1d-403b-8a6a-443ec2453d35" />
<img width="1296" height="951" alt="스크린샷 2025-09-29 오후 9 07 08" src="https://github.com/user-attachments/assets/64ca0c53-d1d5-4fdb-8f10-0b36da5fc24f" />





## 📢 기타 참고 사항
- 블랙리스트 TTL 적용: Access Token은 남은 유효 기간만큼, Refresh Token은 설정된 만료 기간(30일)만큼 Redis에 TTL이 설정되어 관리됩니다.